### PR TITLE
Zombie threads poc

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ducttape/Timeouts.java
+++ b/core/src/main/java/org/testcontainers/utility/ducttape/Timeouts.java
@@ -9,20 +9,28 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class Timeouts {
 
-    private static final ExecutorService EXECUTOR_SERVICE = Executors.newCachedThreadPool(new ThreadFactory() {
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(0);
 
-        final AtomicInteger threadCounter = new AtomicInteger(0);
+    private static final ThreadFactory THREAD_FACTORY = r -> {
+        Thread thread = new Thread(r, "ducttape-" + THREAD_COUNTER.getAndIncrement());
+        thread.setDaemon(true);
+        return thread;
+    };
 
-        @Override
-        public Thread newThread(Runnable r) {
-            Thread thread = new Thread(r, "ducttape-" + threadCounter.getAndIncrement());
-            thread.setDaemon(true);
-            return thread;
+    private static volatile ExecutorService executorService;
+
+    private static synchronized ExecutorService getExecutorService() {
+        if (executorService == null || executorService.isShutdown()) {
+            executorService = Executors.newCachedThreadPool(THREAD_FACTORY);
         }
-    });
+        return executorService;
+    }
 
-    public static void shutdown() {
-        EXECUTOR_SERVICE.shutdown();
+    public static synchronized void shutdown() {
+        if (executorService != null) {
+            executorService.shutdown();
+            executorService = null;
+        }
     }
 
     /**
@@ -40,7 +48,7 @@ public class Timeouts {
 
         check("timeout must be greater than zero", timeout > 0);
 
-        Future<T> future = EXECUTOR_SERVICE.submit(lambda);
+        Future<T> future = getExecutorService().submit(lambda);
         return callFuture(timeout, timeUnit, future);
     }
 
@@ -57,7 +65,7 @@ public class Timeouts {
 
         check("timeout must be greater than zero", timeout > 0);
 
-        Future<?> future = EXECUTOR_SERVICE.submit(lambda);
+        Future<?> future = getExecutorService().submit(lambda);
         callFuture(timeout, timeUnit, future);
     }
 

--- a/core/src/test/java/org/testcontainers/utility/TimeoutsShutdownTest.java
+++ b/core/src/test/java/org/testcontainers/utility/TimeoutsShutdownTest.java
@@ -1,0 +1,35 @@
+package org.testcontainers.utility;
+
+import org.junit.Test;
+import org.testcontainers.utility.ducttape.Timeouts;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link Timeouts} works correctly across shutdown/reuse cycles.
+ * After {@code shutdown()} the executor is re-created on next use.
+ */
+public class TimeoutsShutdownTest {
+
+    @Test
+    public void timeoutsWorkAfterShutdown() {
+        // First use
+        String result1 = Timeouts.getWithTimeout(5, TimeUnit.SECONDS, () -> "container-1-ready");
+        assertThat(result1).isEqualTo("container-1-ready");
+
+        // Shutdown (as GenericContainer.stop() does)
+        Timeouts.shutdown();
+
+        // Second use — should transparently create a fresh executor
+        String result2 = Timeouts.getWithTimeout(5, TimeUnit.SECONDS, () -> "container-2-ready");
+        assertThat(result2).isEqualTo("container-2-ready");
+
+        // Shutdown and use again to confirm repeatable
+        Timeouts.shutdown();
+
+        String result3 = Timeouts.getWithTimeout(5, TimeUnit.SECONDS, () -> "container-3-ready");
+        assertThat(result3).isEqualTo("container-3-ready");
+    }
+}


### PR DESCRIPTION
@dadoonet I'm not sure if you're still tracking [this PR](https://github.com/testcontainers/testcontainers-java/pull/9241) but I wanted to lend a hand. There seems to be a subtle bug in your fix - as the executor service is a singleton, shutting it down from `GenericContainer` causes any future attempts to use timeouts to fail.

This PR-to-your-PR adds a test demonstrating the problem (d506b0c1672a61e2d4448ee0e79ed10dc847cf7e) and a tweak so that we still shut down the executor but replace it with a fresh one (d17370b1f20296bc3c2eb18d6161d1e9040d4404).

We could merge this in to your PR or directly into origin - your choice 🙇 